### PR TITLE
feat: `playwright.config.ts`も除外対象とする[skip actions]

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
       "@/*": ["src/*"]
     }
   },
-  "exclude": ["src/tests"]
+  "exclude": ["playwright.config.ts", "src/tests"]
 }


### PR DESCRIPTION
環境変数`NODE_ENV`の差分で失敗していた。
- 開発環境デプロイ
  - `NODE_ENV=development`なので`npm ci`でPlaywrightがインストールされた
- 本番環境デプロイ
  - `NODE_ENV=production`なので`npm ci`ではPlaywrightがインストールされなかった

…というのがオチ